### PR TITLE
HEARTH-48: Fixed error: objectDetail.length nevern being bigger than 0

### DIFF
--- a/lib/construct.js
+++ b/lib/construct.js
@@ -97,7 +97,8 @@ function ParticipantObjectIdentification(objId, objTypeCode, objTypeCodeRole, ob
   } else if (objQuery) {
     this.ParticipantObjectQuery = objQuery;
   }
-  if (objDetails && objDetails.length > 0) {
+
+  if (objDetails && Object.keys(objDetails).length > 0) {
     this.ParticipantObjectDetail = objDetails;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atna-audit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Assists in the creation of ATNA audit trail messages for IHE profiles.",
   "main": "index.js",
   "scripts": {

--- a/tests/sendAudit.js
+++ b/tests/sendAudit.js
@@ -63,7 +63,6 @@ var setupTLSserver = function (t, originalMsg, port, callback) {
       var message = message.substr(lengthIndex + 1)
 
       if (length === Buffer.byteLength(message)) {
-        console.log('aasas')
         t.equals(message.toString(), originalMsg, 'should receive the same message that was sent')
         server.close();
       }      


### PR DESCRIPTION
This PR fixes a bug where the objectDetails never got included in the message due to the length never being bigger than zero, 

Updated to look at object keys length instead, as this comes through as an object